### PR TITLE
Code fixes for ruby 1.9

### DIFF
--- a/web/lib/javascript.rb
+++ b/web/lib/javascript.rb
@@ -6,7 +6,7 @@ def javascript(url=nil, &block)
 end
 
 def javascript_tags
-    @javascript.map{ |js| js.to_html }
+    @javascript.map{ |js| js.to_html }.join("\n")
 end
 
 class Javascript
@@ -23,9 +23,9 @@ class Javascript
 
     def to_html
         if @file.nil?
-            %Q{    <script type="text/javascript">//<![CDATA[\n#{ @content }//]]></script>\n}
+            %Q{    <script type="text/javascript">//<![CDATA[\n#{ @content }//]]></script>}
         else
-            %Q{    <script type="text/javascript" src="/js/#{ @file }.js"></script>\n}
+            %Q{    <script type="text/javascript" src="/js/#{ @file }.js"></script>}
         end
     end
 

--- a/web/taginfo.rb
+++ b/web/taginfo.rb
@@ -27,6 +27,8 @@
 #
 #------------------------------------------------------------------------------
 
+$LOAD_PATH.unshift(File.dirname(__FILE__))
+
 require 'rubygems'
 require 'json'
 require 'sqlite3'


### PR DESCRIPTION
Hello Jochen,

I made a commit fixing errors with ruby 1.9. There, in fact, map() changed meaning, and it returned a list of strings (instead of a "pure" string). Adding a join() fixes it.

One more fix was needed to correct the import path, since it seems like the current directory isn't added anymore.

Kindly,
David
