### PR TITLE
Use rtype as param for api/4/relation/roles call

### DIFF
--- a/web/lib/api/v4/relation.rb
+++ b/web/lib/api/v4/relation.rb
@@ -5,7 +5,7 @@ class Taginfo < Sinatra::Base
     api(4, 'relation/roles', {
         :description => 'Member role statistics for a relation of given type.',
         :parameters => {
-            :type => 'Relation type (required).',
+            :rtype => 'Relation type (required).',
             :query => 'Only show results where the role matches this query (substring match, optional).'
         },
         :paging => :optional,
@@ -22,10 +22,10 @@ class Taginfo < Sinatra::Base
             [:count_relation_members,          :INT,    'Number of members of type relation with this role.'],
             [:count_relation_members_fraction, :FLOAT,  'Number of members of type relation with this role devided by all members of type relation.']
         ]),
-        :example => { :role => 'multipolygon', :page => 1, :rp => 10 },
+        :example => { :rtype => 'multipolygon', :page => 1, :rp => 10 },
         :ui => '/reports/relation_types#roles'
     }) do
-        rtype = params[:type]
+        rtype = params[:rtype]
 
         relation_type_info = @db.select('SELECT * FROM relation_types').
             condition("rtype=?", rtype).

--- a/web/viewsjs/relation.js.erb
+++ b/web/viewsjs/relation.js.erb
@@ -28,7 +28,7 @@ var create_flexigrid_for = {
     },
     roles: function(rtype) {
         create_flexigrid('grid-roles', {
-            url: '/api/4/relation/roles?type=' + encodeURIComponent(rtype),
+            url: '/api/4/relation/roles?rtype=' + encodeURIComponent(rtype),
             colModel: [
                 { display: '<%= osm.relation_member_role %>', name: 'role', width: 250, sortable: true },
                 { display: '<span title="<%= page.roles.objects_tooltip %>"><img src="/img/types/all.16.png" width="16" height="16" alt=""/> <%= osm.relation_members %></span>', name: 'count_all_members', width: 250, sortable: true, align: 'center' },


### PR DESCRIPTION
Was using type as param which is inconsistent with  api/4/relation/stats call

Also example was using role as param which is incorrect
