### PR TITLE
Map attribution and scaling

### DIFF
--- a/taginfo-config-example.json
+++ b/taginfo-config-example.json
@@ -27,7 +27,9 @@
         "width": 360,
         "height": 180,
         "scale_image": 2,
-        "background_image": "/img/mapbg/world.png"
+        "scale_compare_image" : 1,
+        "background_image": "/img/mapbg/world.png",
+        "image_attribution": ""
     },
     "xapi": {
         // XAPI/JOSM buttons are disabled if more than this many results are expected

--- a/web/lib/ui/compare.rb
+++ b/web/lib/ui/compare.rb
@@ -63,8 +63,8 @@ class Taginfo < Sinatra::Base
             end
         end
 
-        @img_width  = TaginfoConfig.get('geodistribution.width')
-        @img_height = TaginfoConfig.get('geodistribution.height')
+        @img_width  = (TaginfoConfig.get('geodistribution.width')*TaginfoConfig.get('geodistribution.scale_compare_image')).to_i
+        @img_height = (TaginfoConfig.get('geodistribution.height')*TaginfoConfig.get('geodistribution.scale_compare_image')).to_i
 
         javascript "#{ r18n.locale.code }/compare"
         erb :compare

--- a/web/views/compare.erb
+++ b/web/views/compare.erb
@@ -70,6 +70,7 @@
                 <% key_or_tag = data[:value].nil? ? 'key' : 'tag' %>
                 <img class="map" src="/api/4/<%= key_or_tag %>/distribution/nodes?key=<%= data[:key] %><%= data[:value].nil? ? '' : ('&amp;value=' + data[:value]) %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>" style="position: absolute;"/>
                 <img class="map" src="/api/4/<%= key_or_tag %>/distribution/ways?key=<%= data[:key] %><%= data[:value].nil? ? '' : ('&amp;value=' + data[:value]) %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
             </div>
             <% end %>
         </td>

--- a/web/views/key.erb
+++ b/web/views/key.erb
@@ -75,14 +75,17 @@
             <div style="background-image: url(<%= TaginfoConfig.get('geodistribution.background_image') %>); background-repeat: no-repeat; background-position: 1px 1px;"/>
                 <img class="map" src="/api/4/key/distribution/nodes?key=<%= @key_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>" style="position: absolute;"/>
                 <img class="map" src="/api/4/key/distribution/ways?key=<%= @key_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
             </div>
         <% elsif @filter_type == 'nodes' %>
             <div style="background-image: url(<%= TaginfoConfig.get('geodistribution.background_image') %>); background-repeat: no-repeat; background-position: 1px 1px;"/>
                 <img class="map" src="/api/4/key/distribution/nodes?key=<%= @key_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
             </div>
         <% elsif @filter_type == 'ways' %>
             <div style="background-image: url(<%= TaginfoConfig.get('geodistribution.background_image') %>); background-repeat: no-repeat; background-position: 1px 1px;"/>
                 <img class="map" src="/api/4/key/distribution/ways?key=<%= @key_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
             </div>
         <% elsif @filter_type == 'relations' %>
             <p class="empty"><%= h(t.pages.key.geographic_distribution.relations) %></p>

--- a/web/views/tag.erb
+++ b/web/views/tag.erb
@@ -69,14 +69,17 @@
                 <div style="background-image: url(<%= TaginfoConfig.get('geodistribution.background_image') %>); background-repeat: no-repeat; background-position: 1px 1px;"/>
                     <img class="map" src="/api/4/tag/distribution/nodes?key=<%= @key_uri %>&value=<%= @value_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>" style="position: absolute;"/>
                     <img class="map" src="/api/4/tag/distribution/ways?key=<%= @key_uri %>&value=<%= @value_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                    <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
                 </div>
             <% elsif @filter_type == 'nodes' %>
                 <div style="background-image: url(<%= TaginfoConfig.get('geodistribution.background_image') %>); background-repeat: no-repeat; background-position: 1px 1px;"/>
                     <img class="map" src="/api/4/tag/distribution/nodes?key=<%= @key_uri %>&value=<%= @value_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                    <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
                 </div>
             <% elsif @filter_type == 'ways' %>
                 <div style="background-image: url(<%= TaginfoConfig.get('geodistribution.background_image') %>); background-repeat: no-repeat; background-position: 1px 1px;"/>
                     <img class="map" src="/api/4/tag/distribution/ways?key=<%= @key_uri %>&value=<%= @value_uri %>" alt="" width="<%= @img_width %>" height="<%= @img_height %>"/>
+                    <div class="note"><%= TaginfoConfig.get('geodistribution.image_attribution') %></div>
                 </div>
             <% elsif @filter_type == 'relations' %>
                 <p class="empty"><%= h(t.pages.tag.geographic_distribution.relations) %></p>


### PR DESCRIPTION
Adds config options for base map attribution and a separate scale factor for compare maps.

The attribution on the compare page is repeated below each map. That's mildly annoying but changing it requires some more thought about the layout of the page.
