### PR TITLE
Added townlands.ie project file

### DIFF
--- a/sources/projects/project_list.txt
+++ b/sources/projects/project_list.txt
@@ -10,3 +10,4 @@ osmcoastline https://raw.githubusercontent.com/joto/osmcoastline/master/taginfo.
 osrm https://raw.githubusercontent.com/Project-OSRM/osrm-backend/develop/taginfo.json
 vespucci https://osmeditor4android.googlecode.com/svn/trunk/taginfo.json
 waymarkedtrails http://mapstatic.waymarkedtrails.org/taginfo.json
+townlands_ie http://www.townlands.ie/taginfo.json


### PR DESCRIPTION
The OpenStreetMap community in Ireland is busy adding "townlands". These are the lowest level of administrative division in Ireland, are used extensively for rural addresses, are the building blocks for all administrative divisions in Ireland, and are used extensively in history and genealogy. We have also been mapping baronies and civil parishes. There is very few sources of this data.

To help, I have created townlands.ie, a site which shows all the townlands that we have added. It's been very help for OSM mappers to see how much is left to do, spot errors (overlaps, gaps etc). It is also a great resource to show people the power of OSM and open data.

Hence, I'd like the tags used to map these townlands in taginfo.
