### PR TITLE
Make the update script more portable

### DIFF
--- a/sources/master/update.sh
+++ b/sources/master/update.sh
@@ -9,6 +9,7 @@ set -e
 
 DIR=$1
 
+[ -n "$M4" ] || M4=m4
 DATECMD='date +%Y-%m-%dT%H:%M:%S'
 
 if [ "x" = "x$DIR" ]; then
@@ -25,13 +26,13 @@ SELECTION_DB=$DIR/selection.db
 echo "`$DATECMD` Create search database..."
 
 rm -f $DIR/taginfo-search.db
-m4 --prefix-builtins -D __DIR__=$DIR search.sql | sqlite3 $DIR/taginfo-search.db
+$M4 --prefix-builtins -D __DIR__=$DIR search.sql | sqlite3 $DIR/taginfo-search.db
 
 echo "`$DATECMD` Create master database..."
 
 rm -f $MASTER_DB
 sqlite3 $MASTER_DB <languages.sql
-m4 --prefix-builtins -D __DIR__=$DIR master.sql | sqlite3 $MASTER_DB
+$M4 --prefix-builtins -D __DIR__=$DIR master.sql | sqlite3 $MASTER_DB
 
 echo "`$DATECMD` Create selection database..."
 
@@ -40,7 +41,7 @@ min_count_for_map=`../../bin/taginfo-config.rb sources.master.min_count_for_map 
 min_count_relations_per_type=`../../bin/taginfo-config.rb sources.master.min_count_relations_per_type 100`
 
 rm -f $SELECTION_DB
-m4 --prefix-builtins \
+$M4 --prefix-builtins \
    -D __DIR__=$DIR \
    -D __MIN_COUNT_FOR_MAP__=$min_count_for_map \
    -D __MIN_COUNT_TAGS__=$min_count_tags \
@@ -56,7 +57,7 @@ if [ ! -e $HISTORY_DB ]; then
     sqlite3 $HISTORY_DB < history_init.sql
 fi
 
-m4 --prefix-builtins -D __DIR__=$DIR history_update.sql | sqlite3 $HISTORY_DB
+$M4 --prefix-builtins -D __DIR__=$DIR history_update.sql | sqlite3 $HISTORY_DB
 
 echo "`$DATECMD` Done master."
 


### PR DESCRIPTION
On FreeBSD, "m4" is slightly different to GNU M4, for example,
--prefix-builtins is GNU M4 only feature. GNU M4 is an external package
at /usr/local/bin/gm4. So make it customable variable.
