### PR TITLE
Prevent download db files if not updated yet

### DIFF
--- a/sources/update_all.sh
+++ b/sources/update_all.sh
@@ -50,7 +50,7 @@ for source in $SOURCES_DOWNLOAD; do
     echo "====================================="
     echo "Downloading $source..."
     mkdir -p $DIR/$source
-    curl --silent --fail --output $DIR/download/taginfo-$source.db.bz2 http://taginfo.openstreetmap.org/download/taginfo-$source.db.bz2
+    curl --silent --fail --output $DIR/download/taginfo-$source.db.bz2 --time-cond $DIR/download/taginfo-$source.db.bz2 http://taginfo.openstreetmap.org/download/taginfo-$source.db.bz2
     bzcat $DIR/download/taginfo-$source.db.bz2 >$DIR/$source/taginfo-$source.db
     echo "Done."
 done


### PR DESCRIPTION
This is no effect to production server since the main server update
everyday. However, this is helpful for test sites, which may run update
script several times during developing.
