### PR TITLE
search/by_keyword does not sort by count_all

### DIFF
--- a/web/lib/api/v4/search.rb
+++ b/web/lib/api/v4/search.rb
@@ -49,7 +49,7 @@ class Taginfo < Sinatra::Base
     api(4, 'search/by_keyword', {
         :description => 'Search for keys and tags by keyword in wiki pages.',
         :parameters => { :query => 'Value to search for (substring search, required).' },
-        :sort => %w( count_all key value ),
+        :sort => %w( key value ),
         :paging => :optional,
         :result => paging_results([
             [:key,   :STRING, 'Key'],


### PR DESCRIPTION
The call doesn't actually return a count_all field and for that reason can't sort by it.