### PR TITLE
Remove anchors from regular expression routes

### DIFF
--- a/web/lib/ui/compare.rb
+++ b/web/lib/ui/compare.rb
@@ -1,7 +1,7 @@
 # web/lib/ui/compare.rb
 class Taginfo < Sinatra::Base
 
-    get %r{^/compare/(.*)} do |items|
+    get %r{/compare/(.*)} do |items|
         @data = []
 
         if !items.nil?

--- a/web/lib/ui/keys.rb
+++ b/web/lib/ui/keys.rb
@@ -1,7 +1,7 @@
 # web/lib/ui/keys.rb
 class Taginfo < Sinatra::Base
 
-    get %r{^/keys/(.*)} do |key|
+    get %r{/keys/(.*)} do |key|
         if params[:key].nil?
             @key = key
         else

--- a/web/lib/ui/projects.rb
+++ b/web/lib/ui/projects.rb
@@ -9,7 +9,7 @@ class Taginfo < Sinatra::Base
         erb :projects
     end
 
-    get %r{^/projects/(.*)} do |project|
+    get %r{/projects/(.*)} do |project|
         if params[:project].nil?
             @project_id = project
         else

--- a/web/lib/ui/relation.rb
+++ b/web/lib/ui/relation.rb
@@ -1,7 +1,7 @@
 # web/lib/ui/relations.rb
 class Taginfo < Sinatra::Base
 
-    get %r{^/relations/(.*)} do |rtype|
+    get %r{/relations/(.*)} do |rtype|
         if params[:rtype].nil?
             @rtype = rtype
         else

--- a/web/lib/ui/tags.rb
+++ b/web/lib/ui/tags.rb
@@ -1,7 +1,7 @@
 # web/lib/ui/tags.rb
 class Taginfo < Sinatra::Base
 
-    get %r{^/tags/(.*)} do |tag|
+    get %r{/tags/(.*)} do |tag|
         if tag.match(/=/)
             kv = tag.split('=', 2)
         else

--- a/web/taginfo.rb
+++ b/web/taginfo.rb
@@ -195,7 +195,7 @@ class Taginfo < Sinatra::Base
 
     #-------------------------------------
 
-    get %r{^/js/([a-z][a-z](-[a-zA-Z]+)?)/(.*).js$} do |lang, dummy, js|
+    get %r{/js/([a-z][a-z](-[a-zA-Z]+)?)/(.*).js} do |lang, dummy, js|
         expires next_update
         @lang = lang
         @trans = R18n::I18n.new(lang, 'i18n')


### PR DESCRIPTION
Sinatra 2 anchors implicitly, and will complain if the pattern for a route has explicit anchors.

I think, though I'm not entirely sure, that the anchors are required in Sinatra 1.x, so this might need to be documented properly.