### PR TITLE
Use bundler to install ruby modules

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'rack'
+gem 'rack-contrib'
+gem 'sinatra', '~> 2.0.0'
+gem 'sinatra-i18n'
+gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,30 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    json (2.1.0)
+    mustermann (1.0.2)
+    rack (2.0.5)
+    rack-contrib (2.0.1)
+      rack (~> 2.0)
+    rack-protection (2.0.3)
+      rack
+    sinatra (2.0.3)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.3)
+      tilt (~> 2.0)
+    sinatra-i18n (0.1.0)
+    tilt (2.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  json
+  rack
+  rack-contrib
+  sinatra (~> 2.0.0)
+  sinatra-i18n
+
+BUNDLED WITH
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ $ sudo apt-get install ruby-passenger libapache2-mod-passenger
 
 Install the Gems:
 ```sh
-$ sudo gem install rack rack-contrib sinatra sinatra-r18n json
+$ sudo gem install bundler
+$ sudo bundle install
 ```
 
 ## Data Import


### PR DESCRIPTION
Using bundler ensure that users get versions that we know will work rather than newer versions that require code changes.

This was triggered by #230 which was in turn triggered by me upgrading the live servers to Ubutnu 18.04 which moved us to ruby 2.5 and lead to Sinatra 2.x being installed by the chef recipes. I have rolled back to 1.x for now.