### PR TITLE
key.rb: highway=residential is a tag, not a key

### DIFF
--- a/web/lib/api/v4/key.rb
+++ b/web/lib/api/v4/key.rb
@@ -339,7 +339,7 @@ class Taginfo < Sinatra::Base
             [:icon_url,         :STRING, 'Icon URL']
         ]),
         :example => { :key => 'highway', :page => 1, :rp => 10, :sortname => 'project_name', :sortorder => 'asc' },
-        :ui => '/keys/highway=residential#projects'
+        :ui => '/keys/highway#projects'
     }) do
         key = params[:key]
         q = like_contains(params[:query])


### PR DESCRIPTION
The [UI example for projects](https://taginfo.openstreetmap.org/keys/highway=residential#projects) doesn't yield any results; this replacement should fix it.