### PR TITLE
Always call JOSM over http

### DIFF
--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -735,11 +735,6 @@ function comparison_list_change(key, value) {
 
 function activate_josm_button() {
     if (jQuery('#josm_button').length != 0) {
-        if (window.location.protocol == "https:") {
-            var url = jQuery('#josm_button')[0].href.replace('http://localhost:8111/', 'https://localhost:8112/');
-            jQuery('#josm_button')[0].href = url;
-        }
-
         jQuery('#josm_button').bind('click', function() {
             var url = jQuery('#josm_button')[0].href;
             jQuery.get(url, function(data) {


### PR DESCRIPTION
Https in JOSM is unreliable and will be dropped soon. See https://josm.openstreetmap.de/ticket/10033

All modern browsers support calling 127.0.0.1 over http even from https pages, per spec:

w3c/webappsec-mixed-content@349501c
https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy

JOSM's default behaviour is to run without https.

Openstreetmap.org itself also always calls JOSM over http.