### PR TITLE
Update the Chinese translations of taglists.js

### DIFF
--- a/web/public/js/taglists.js
+++ b/web/public/js/taglists.js
@@ -187,14 +187,23 @@ var taginfo_taglist = (function(){
                 'osmcarto_rendering': 'Hình tượng',
                 'count': 'Tổng số'
             },
-            'zh-TW': {
-                'key': '鍵',
-                'value': '值',
-                'element': '類型',
-                'description': '描述',
-                'image': '圖片',
-                'osmcarto_rendering': '圖示',
-                'count': '計數'
+            'zh-hans': { 
+                'key': '类别', 
+                'value': '值', 
+                'element': '元素', 
+                'description': '说明', 
+                'image': '照片', 
+                'osmcarto_rendering': '地图显示', 
+                'count': '计数' 
+            },
+            'zh-hant': { 
+                'key': '鍵', 
+                'value': '值', 
+                'element': '元素', 
+                'description': '描述', 
+                'image': '照片', 
+                'osmcarto_rendering': '地圖標註', 
+                'count': '計數' 
             }
         };
 


### PR DESCRIPTION
As I'd post on the issue https://github.com/taginfo/taginfo/issues/278, changing deprecated 'zh-Tw' into 'zh-hant' and add 'zh-hans'.