### PR TITLE
clarify that chronology results are deltas

### DIFF
--- a/web/lib/api/v4/key.rb
+++ b/web/lib/api/v4/key.rb
@@ -397,9 +397,9 @@ class Taginfo < Sinatra::Base
         :paging => :no,
         :result => no_paging_results([
             [:date,      :TEXT, 'Date in format YYYY-MM-DD.'],
-            [:nodes,     :INT, 'Number of nodes with this key.'],
-            [:ways,      :INT, 'Number of ways with this key.'],
-            [:relations, :INT, 'Number of relations with this key.']
+            [:nodes,     :INT, 'Difference of number of nodes with this key relative to previous entry.'],
+            [:ways,      :INT, 'Difference of number of ways with this key relative to previous entry.'],
+            [:relations, :INT, 'Difference of number of relations with this key relative to previous entry.']
         ]),
         :example => { :key => 'highway' },
         :ui => '/keys/highway#chronology'

--- a/web/lib/api/v4/tag.rb
+++ b/web/lib/api/v4/tag.rb
@@ -267,9 +267,9 @@ class Taginfo < Sinatra::Base
         :paging => :no,
         :result => no_paging_results([
             [:date,      :TEXT, 'Date in format YYYY-MM-DD.'],
-            [:nodes,     :INT, 'Number of nodes with this tag.'],
-            [:ways,      :INT, 'Number of ways with this tag.'],
-            [:relations, :INT, 'Number of relations with this tag.']
+            [:nodes,     :INT, 'Difference of number of nodes with this tag relative to previous entry.'],
+            [:ways,      :INT, 'Difference of number of ways with this tag relative to previous entry.'],
+            [:relations, :INT, 'Difference of number of relations with this tag relative to previous entry.']
         ]),
         :example => { :key => 'highway', :value => 'primary' },
         :ui => '/tags/highway=primary#chronology'


### PR DESCRIPTION
The numbers returned for each timestamp are not the total _number of nodes/ways/relations with that key_, but rather the difference on that day. That's why the latest entries in [`/key/chronology?key=created_by`](https://taginfo.openstreetmap.org/api/4/key/chronology?key=created_by) are all negative :wink: .