### PR TITLE
Move configuration to a variable

### DIFF
--- a/web/lib/config.rb
+++ b/web/lib/config.rb
@@ -2,16 +2,22 @@
 
 class TaginfoConfig
 
-    @@config = {}
+    @config = {}
+    @id = ''
 
-    def self.read
-        open(File.expand_path(File.dirname(__FILE__)) + '/../../../taginfo-config.json') do |file|
-            @@config = JSON.parse(file.gets(nil), { :create_additions => false })
+    def initialize(configfile, id)
+        open(configfile) do |file|
+            @config = JSON.parse(file.gets(nil), { :create_additions => false })
         end
+        @id = id
     end
 
-    def self.get(key, default=nil)
-        tree = @@config
+    def id
+        @id
+    end
+
+    def get(key, default=nil)
+        tree = @config
         key.split('.').each do |i|
             tree = tree[i]
             return default unless tree
@@ -21,8 +27,8 @@ class TaginfoConfig
 
     # Config without anything that a security concious admin wouldn't want to
     # be public. Currently everything that contains local paths is removed.
-    def self.sanitized_config
-        c = @@config
+    def sanitized_config
+        c = @config
         c['paths'] && c.delete('paths')
         c['sources'] && c['sources'].delete('db')
         c['sources'] && c['sources'].delete('chronology')

--- a/web/lib/sources.rb
+++ b/web/lib/sources.rb
@@ -1,4 +1,32 @@
 # web/lib/sources.rb
+class Sources
+
+    def initialize(taginfo_config)
+       @taginfo_config = taginfo_config
+       @sources = Array.new
+    end
+
+    # Enumerate all available sources
+    def each
+        @sources.each do |source|
+            yield source
+        end
+    end
+
+    # The number of available sources
+    def size
+        @sources.size
+    end
+
+    def visible
+        @sources.select{ |source| source.visible }
+    end
+
+    def add(id, name, data_until, update_start, update_end, visible)
+        @sources << Source.new(@taginfo_config, id, name, data_until, update_start, update_end, visible)
+    end
+end
+
 class Source
 
     @@sources = Hash.new

--- a/web/lib/sources.rb
+++ b/web/lib/sources.rb
@@ -33,6 +33,11 @@ class Source
 
     attr_reader :id, :name, :data_until, :update_start, :update_end, :visible, :dbsize, :dbpack
 
+    def initialize(taginfo_config)
+       @taginfo_config = taginfo_config
+       @sources = Array.new
+    end
+
     # Enumerate all available sources
     def self.each
         @@sources.values.each do |source|
@@ -41,8 +46,12 @@ class Source
     end
 
     # The number of available sources
-    def self.size
-        @@sources.size
+    def size
+        @sources.size
+    end
+
+    def visible
+        @sources.select{ |source| source.visible }
     end
 
     def self.visible
@@ -52,8 +61,6 @@ class Source
     def self.get(id)
         @@sources[id]
     end
-
-    # Create new source
     #  id - Symbol with id for this source
     #  name - Name of this source
     def initialize(taginfo_config, id, name, data_until, update_start, update_end, visible)

--- a/web/lib/sources.rb
+++ b/web/lib/sources.rb
@@ -28,7 +28,7 @@ class Source
     # Create new source
     #  id - Symbol with id for this source
     #  name - Name of this source
-    def initialize(id, name, data_until, update_start, update_end, visible)
+    def initialize(taginfo_config, id, name, data_until, update_start, update_end, visible)
         @id           = id.to_sym
         @name         = name
         @data_until   = data_until
@@ -36,8 +36,8 @@ class Source
         @update_end   = update_end
         @visible      = visible
 
-        data_dir = TaginfoConfig.get('paths.data_dir', '../../data')
-        download_dir = TaginfoConfig.get('paths.download_dir', '../../download')
+        data_dir = taginfo_config.get('paths.data_dir', '../../data')
+        download_dir = taginfo_config.get('paths.download_dir', '../../download')
         @dbsize = File.size("#{ data_dir }/#{ dbname }").to_bytes rescue 0
         @dbpack = File.size("#{ download_dir }/#{ dbname }.bz2").to_bytes rescue 0
 

--- a/web/lib/sql.rb
+++ b/web/lib/sql.rb
@@ -6,23 +6,6 @@ module SQL
     # Wrapper for a database connection.
     class Database
 
-        # This has to be called once to initialize the context for the database
-        def self.init(dir)
-            @@dir = dir
-
-            db = SQL::Database.new
-
-            db.select('SELECT * FROM sources ORDER BY no').execute().each do |source|
-                Source.new(source['id'], source['name'], source['data_until'], source['update_start'], source['update_end'], source['visible'].to_i == 1)
-            end
-
-            data_until = db.select("SELECT min(data_until) FROM sources WHERE id='db'").get_first_value()
-
-            db.close
-
-            data_until
-        end
-
         def initialize(taginfo_config)
             @dir = taginfo_config.get('paths.data_dir')
             filename = @dir + '/taginfo-master.db'

--- a/web/lib/ui/taginfo.rb
+++ b/web/lib/ui/taginfo.rb
@@ -60,7 +60,7 @@ class Taginfo < Sinatra::Base
 
     get '/taginfo/status' do
         content_type 'text/plain'
-        age_in_days = DateTime.now() - DateTime.parse(@data_until)
+        age_in_days = DateTime.now() - DateTime.parse(@db.data_until)
         if age_in_days.to_f > 1.5
             halt 400, "data_too_old\n"
         else

--- a/web/lib/utils.rb
+++ b/web/lib/utils.rb
@@ -44,7 +44,7 @@ end
 def title
     @title = [] if @title.nil?
     @title = [@title] unless @title.is_a?(Array)
-    @title << TaginfoConfig.get('instance.name', 'OpenStreetMap Taginfo')
+    @title << @taginfo_config.get('instance.name', 'OpenStreetMap Taginfo')
     @title.join(' | ')
 end
 

--- a/web/lib/utils.rb
+++ b/web/lib/utils.rb
@@ -84,7 +84,7 @@ def xapi_url(element, key, value=nil)
     else
         predicate += xapi_escape(value)
     end
-    TaginfoConfig.get('xapi.url_prefix', 'http://www.informationfreeway.org/api/0.6/') + "#{ element }[#{ Rack::Utils::escape(predicate) }]"
+    @taginfo_config.get('xapi.url_prefix', 'http://www.informationfreeway.org/api/0.6/') + "#{ element }[#{ Rack::Utils::escape(predicate) }]"
 end
 
 def xapi_link(element, key, value=nil)
@@ -100,7 +100,7 @@ def quote_double(text)
 end
 
 def turbo_link(count, filter, key, value=nil)
-    if count <= TaginfoConfig.get('turbo.max_auto', 100)
+    if count <= @taginfo_config.get('turbo.max_auto', 100)
         key = quote_double(key)
         if value.nil?
             value = '*'
@@ -110,7 +110,7 @@ def turbo_link(count, filter, key, value=nil)
         if filter != 'all'
             filter_condition = ' and type:' + filter.chop
         end
-        url = TaginfoConfig.get('turbo.url_prefix', 'https://overpass-turbo.eu/?') + 'w=' + Rack::Utils::escape('"' + key + '"=' + value + filter_condition.to_s + ' ' + TaginfoConfig.get('turbo.wizard_area', 'global')) + '&R'
+        url = @taginfo_config.get('turbo.url_prefix', 'https://overpass-turbo.eu/?') + 'w=' + Rack::Utils::escape('"' + key + '"=' + value + filter_condition.to_s + ' ' + @taginfo_config.get('turbo.wizard_area', 'global')) + '&R'
     else
         template = 'key';
         parameters = { :key => key }
@@ -126,7 +126,7 @@ def turbo_link(count, filter, key, value=nil)
         end
         parameters[:template] = template
 
-        url = TaginfoConfig.get('turbo.url_prefix', 'https://overpass-turbo.eu/?') + Rack::Utils::build_query(parameters)
+        url = @taginfo_config.get('turbo.url_prefix', 'https://overpass-turbo.eu/?') + Rack::Utils::build_query(parameters)
     end
     return external_link('turbo_button', 'Overpass turbo', url, true)
 end
@@ -148,9 +148,9 @@ def level0_url(filter, key, value)
         query = '(node' + query + 'way' + query + '>;rel' + query + ');'
     end
 
-    overpass_url = TaginfoConfig.get('level0.overpass_url_prefix') + Rack::Utils::build_query({ :data => '[out:xml];' + query + 'out meta;' })
+    overpass_url = @taginfo_config.get('level0.overpass_url_prefix') + Rack::Utils::build_query({ :data => '[out:xml];' + query + 'out meta;' })
 
-    return TaginfoConfig.get('level0.level0_url_prefix') + Rack::Utils::build_query({ :url => overpass_url })
+    return @taginfo_config.get('level0.level0_url_prefix') + Rack::Utils::build_query({ :url => overpass_url })
 end
 
 def level0_link(filter, key, value=nil)
@@ -365,4 +365,3 @@ def unpack_chronology(raw_data)
 
     return data
 end
-

--- a/web/taginfo.rb
+++ b/web/taginfo.rb
@@ -65,8 +65,6 @@ TAGINFO_CONFIG = TaginfoConfig.new('../../taginfo-config.json', nil);
 ALL_SECTIONS = %w(download taginfo test)
 SECTIONS = Hash[TAGINFO_CONFIG.get('instance.sections', ALL_SECTIONS).collect { |s| [s.to_sym, s] } ]
 
-# FRED DATA_UNTIL = SQL::Database.init(TaginfoConfig.get('paths.data_dir', '../../data'));
-
 class Taginfo < Sinatra::Base
 
     register Sinatra::R18n

--- a/web/views/sources.erb
+++ b/web/views/sources.erb
@@ -13,7 +13,7 @@
     <tr>
         <td class="box">
             <p><%= h(t.pages.sources.list.intro) %></p>
-<% Source.visible.each_with_index do |source, n| c = (n%2!=0) ? ' even' : '' %>
+<% @db.sources.visible.each_with_index do |source, n| c = (n%2!=0) ? ' even' : '' %>
             <h2><%= h(t.sources[source.id].name) %></h2>
             <%= t.pages.sources.description[source.id] %>
 <% end %>
@@ -26,7 +26,7 @@
                     <th><%= h(t.pages.sources.data_until) %>*</th>
                     <th><%= h(t.pages.sources.last_update_run) %></th>
                 </tr>
-<% Source.visible.each_with_index do |source, n| c = (n%2!=0) ? ' even' : '' %>
+<% @db.sources.visible.each_with_index do |source, n| c = (n%2!=0) ? ' even' : '' %>
                 <tr>
                     <td class="<%= c %>"><%= h(t.sources[source.id].name) %>
                     <td class="tc<%= c %> nowrap"><%= h(source.data_until) %> UTC</td>


### PR DESCRIPTION
In preparation for enabling taginfo to handle different databases, this pull request moves the configuration from a static class with class variables to an instantiated class that lives in a variable. The sources and database get the same treatment, so that in the future it becomes possible to keep different configurations and choose between them on a per-request basis.
