### PR TITLE
Minor changes to dutch translation

### DIFF
--- a/web/i18n/nl.yml
+++ b/web/i18n/nl.yml
@@ -689,8 +689,8 @@ reports:
         name: Wiki-afbeeldingen
         intro: |
             Afbeeldingen worden gebruikt in de wiki om sleutels te symboliseren in verschillende
-            talen. Soms is de afbeelding van de ene taal beter als van de andere
-            Maar soms is het juist logisch om verschillende afbeeldingen te hebben,
+            talen. Soms is de afbeelding van de ene taal beter als van de andere.
+            Het is soms echter juist logisch om verschillende afbeeldingen te hebben,
             bijvoorbeeld wegens verschillende culturele achtergronden en dergelijke.
     wiki_problems:
         name: Wiki analyseproblemen

--- a/web/i18n/nl.yml
+++ b/web/i18n/nl.yml
@@ -652,7 +652,7 @@ reports:
                 (BCP47)</a>. Taal
                 tags bestaan uit een of meer <i>subtags</i> die de taal, script,
                 varianten en dergelijke beschrijven. De volgende lijst geeft de subtags weer die op dit moment
-                geregistreerd zijn die relevant zijn voor OSM. Voor meer informatie bekijk ook de
+                geregistreerd zijn en die relevant zijn voor OSM. Voor meer informatie bekijk ook de
                 <a href="https://en.wikipedia.org/wiki/IETF_language_tag">Wikipedia
                 pagina over IETF taal tags</a> en de <a
                 href="http://www.langtag.net/">langtag.net</a> website.</p>


### PR DESCRIPTION
This PR suggests two minor changes to the Dutch translation
- Addition of "and" to repeating "that" to indicate a subset of "[registered] subtags".
- Addition of 'but' in seperate sentence to indicate a counterargument for certain cases.
(second commit should say "repeating 'sometimes'")