### PR TITLE
Add support for implies and combination params to Relation pages

### DIFF
--- a/sources/wiki/get_wiki_data.rb
+++ b/sources/wiki/get_wiki_data.rb
@@ -484,6 +484,8 @@ class RelationPage < WikiPage
         super(type, timestamp, namespace, title)
 
         @rtype = title.gsub(/^([^:]+:)?Relation:/, '') # relation type
+        @tags_implies = []
+        @tags_combination = []
 
         m = /^(.*):Relation:/.match(title)
         @lang = m ? m[1].downcase : 'en' # IETF language tag


### PR DESCRIPTION
The RelationDescription template supports "implies" and "combination" parameters, but the code crashes on them. This should fix that.

See https://wiki.openstreetmap.org/wiki/Template:RelationDescription

and an example on https://wiki.openstreetmap.org/wiki/Relation%3Atunnel