### PR TITLE
don't double-escape "key" parameter in ohsome dashboard link

### DIFF
--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -1598,7 +1598,7 @@ function activateTagHistoryButton(data) {
 function activateOhsomeButton(filter, key, value = '') {
     let p = new URLSearchParams({
         backend: 'ohsomeApi',
-        key: encodeURIComponent(key),
+        key: key,
         value: value
     });
 


### PR DESCRIPTION
The _ohsome_ link does not work properly for tags with special characters in the key, e.g. [`addr:housenumber`](https://taginfo.openstreetmap.org/keys/addr%3Ahousenumber#overview).

This fixes it by removing the unnecessary encoding of the `key` paramters in the `URLSearchParams`: this object does already perform the encoding/escaping of special characters [internally](https://url.spec.whatwg.org/#urlsearchparams) (using the application/x-www-form-urlencode format).