### PR TITLE
disable autocapitalize on search input

### DIFF
--- a/web/views/layout.erb
+++ b/web/views/layout.erb
@@ -35,7 +35,7 @@
             </form>
 <% unless @nosearch %>
             <form id="search_form" action="<%= build_link('/search') %>">
-                <input type="text" id="search" name="q" value="<%= h(params[:q]) %>" autocomplete="off"/>
+                <input type="text" id="search" name="q" value="<%= h(params[:q]) %>" autocomplete="off" autocapitalize="off"/>
                 <div id="suggestions"></div>
             </form>
 <% end %>


### PR DESCRIPTION
autocapitalize on mobile keyboards are not useful for the search.

ref https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize