### PR TITLE
Update taglists.js (complete 'de' translation)

### DIFF
--- a/web/public/js/taglists.js
+++ b/web/public/js/taglists.js
@@ -61,8 +61,8 @@ var taginfo_taglist = (function(){
                 'count': 'Počet'
             },
             'de': {
-                'key': 'Key',
-                'value': 'Value',
+                'key': 'Schlüssel',
+                'value': 'Wert',
                 'element': 'Element',
                 'description': 'Beschreibung',
                 'image': 'Bild',


### PR DESCRIPTION
Fix of weird looking mix of EN and DE table titles on wiki pages:

![grafik](https://github.com/user-attachments/assets/10448035-231f-4a4a-925e-69ad4cf8d0d0)
<sup>source: https://wiki.openstreetmap.org/wiki/DE:Key:hazard</sup>

key/value => Schlüssel/Wert