### PR TITLE
Add &redlink=1 to links for creating wiki pages

### DIFF
--- a/web/views/key.erb
+++ b/web/views/key.erb
@@ -148,7 +148,7 @@
             <div id="grid-wiki"></div>
         <% else %>
             <p class="empty"><%= h(t.pages.key.wiki_pages.none_found) %></p>
-            <p><a class="extlink" target="_blank" rel="nofollow" href="//wiki.openstreetmap.org/w/index.php?action=edit&title=Key:<%= @key_uri %>"><%= h(t.pages.key.wiki_pages.create) %></a></p>
+            <p><a class="extlink" target="_blank" rel="nofollow" href="//wiki.openstreetmap.org/w/index.php?action=edit&redlink=1&title=Key:<%= @key_uri %>"><%= h(t.pages.key.wiki_pages.create) %></a></p>
         <% end %>
     </div>
     <div id="projects">

--- a/web/views/relation.erb
+++ b/web/views/relation.erb
@@ -79,7 +79,7 @@
             <div id="grid-wiki"></div>
         <% else %>
             <p class="empty"><%= h(t.pages.relation.wiki_pages.none_found) %></p>
-            <p><a class="extlink" target="_blank" rel="nofollow" href="//wiki.openstreetmap.org/w/index.php?action=edit&title=Relation:<%= @rtype_uri %>"><%= h(t.pages.relation.wiki_pages.create) %></a></p>
+            <p><a class="extlink" target="_blank" rel="nofollow" href="//wiki.openstreetmap.org/w/index.php?action=edit&redlink=1&title=Relation:<%= @rtype_uri %>"><%= h(t.pages.relation.wiki_pages.create) %></a></p>
         <% end %>
     </div>
     <div id="projects">

--- a/web/views/tag.erb
+++ b/web/views/tag.erb
@@ -155,7 +155,7 @@
             <div id="grid-wiki"></div>
         <% else %>
             <p class="empty"><%= h(t.pages.tag.wiki_pages.none_found) %> <%= @wiki_count_key > 0 ? t.pages.tag.wiki_pages.suggest_key_wiki_page('<span id="keylink"></span>') : '' %></p>
-            <p><a class="extlink" target="_blank" rel="nofollow" href="//wiki.openstreetmap.org/w/index.php?action=edit&title=Tag:<%= escape(@tag) %>"><%= h(t.pages.tag.wiki_pages.create) %></a></p>
+            <p><a class="extlink" target="_blank" rel="nofollow" href="//wiki.openstreetmap.org/w/index.php?action=edit&redlink=1&title=Tag:<%= escape(@tag) %>"><%= h(t.pages.tag.wiki_pages.create) %></a></p>
         <% end %>
     </div>
     <div id="projects">


### PR DESCRIPTION
If a wiki page has already been created after Taginfo last crawled the wiki, the "Create wiki page" link will now show the existing page for reading, instead of directly loading the existing page into the editor.

(This is the same behaviour as "red links" within the wiki.)