### PR TITLE
Delay pop up of comparison list.

### DIFF
--- a/web/public/css/taginfo.css
+++ b/web/public/css/taginfo.css
@@ -760,7 +760,7 @@ html[dir="rtl"] #comparison-list {
 }
 
 #comparison-list ul {
-    display: none;
+    visibility: hidden;
     position: absolute;
     margin-top: 1px;
     margin-left: 10px;
@@ -777,7 +777,9 @@ html[dir="rtl"] #comparison-list {
 }
 
 #comparison-list:hover ul {
-    display: block;
+    visibility: visible;
+    transition-property: visibility;
+    transition-delay: .2s;
 }
 
 /* ========== */


### PR DESCRIPTION
The drop down menu of the comparison list opens immediately when hovering it. This hides the links for JOSM and Level0 if you approach them from the top. A minimal delay makes the links accessible much more easily.