### PR TITLE
Fix buildUrl for absolute URLs in export links

### DIFF
--- a/web/public/js/taginfo.js
+++ b/web/public/js/taginfo.js
@@ -1090,8 +1090,8 @@ class DynamicTable {
             if (this.toolbar) {
                 this.toolbar.querySelector('.dt-page input').value = '0';
                 this.toolbar.querySelector('.dt-page span.dt-page-max').innerText = '0';
-                this.toolbar.querySelector('.dt-json a').setAttribute('href', build_link(data.url));
-                this.toolbar.querySelector('.dt-csv a')?.setAttribute('href', build_link(data.url + '&format=csv'));
+                this.toolbar.querySelector('.dt-json a').setAttribute('href', this.buildURL());
+                this.toolbar.querySelector('.dt-csv a')?.setAttribute('href', this.buildURL() + '&format=csv');
                 this.toolbar.querySelector('.dt-info').innerText = texts.dynamic_table.nomsg;
             }
 
@@ -1120,8 +1120,8 @@ class DynamicTable {
         if (this.toolbar) {
             this.toolbar.querySelector('.dt-page input').value = this.currentPage + 1;
             this.toolbar.querySelector('.dt-page span.dt-page-max').innerText = this.maxPage;
-            this.toolbar.querySelector('.dt-json a').setAttribute('href', build_link(data.url));
-            this.toolbar.querySelector('.dt-csv a')?.setAttribute('href', build_link(data.url + '&format=csv'));
+            this.toolbar.querySelector('.dt-json a').setAttribute('href', this.buildURL());
+            this.toolbar.querySelector('.dt-csv a')?.setAttribute('href', this.buildURL() + '&format=csv');
 
             this.toolbar.querySelector('.dt-info').innerHTML = this.fromToMessage();
         }


### PR DESCRIPTION
Fixes https://github.com/taginfo/taginfo/issues/492

This is the LLM supported solution to https://github.com/taginfo/taginfo/issues/492

I don't have taginfo running locally and don't know the codebase so take this as a suggestion that may or may not be the right approach. Below is the LLM analysis that might help someone who knows the codebase to evaluate the solution.

---

<details><summary>LLM Summary</summary>
<p>


> # Fix regional Taginfo export URLs (issue #492)
> 
> ## Root cause
> 
> On regional instances (e.g. `https://taginfo.geofabrik.de/europe:germany/keys/...`), the export links are built as:
> 
> 1. The API returns `url: request.url` in the JSON response ([web/lib/api.rb](web/lib/api.rb) line 204). That value is the full request URL as seen by the server (e.g. `https://taginfo.geofabrik.de/api/4/key/values?key=...`), which in some deployments does **not** include the section path (e.g. `/europe:germany`).
> 2. The frontend then does `build_link(data.url)` ([web/public/js/taginfo.js](web/public/js/taginfo.js) lines 1092–1094, 1123–1124). The JS `build_link(path)` prepends the section: `'/' + context.instance + path`.
> 3. So when `data.url` is already an absolute URL, the result is `'/' + 'europe:germany' + 'https://taginfo.geofabrik.de/api/4/...'` → `/europe:germanyhttps://taginfo.geofabrik.de/api/4/...`, which the browser resolves to the broken link reported in the issue.
> 
> Commit [b43db4f](https://github.com/taginfo/taginfo/commit/b43db4f1b078191cb88680a168e03a77dc1f4352) (fix for #438) already used `build_link(data.url)` for the dt-json/dt-csv links, but that only works when the API returns a **path-only** URL. When the API returns a full URL, prepending the section produces the double-URL bug.
> 
> ## Solution
> 
> Use the URL that the **client** already builds for the same request — `this.buildURL()` — for the JSON and CSV export links, instead of `data.url`. That URL is built with `build_link(this.config.url, p)` and therefore always has the correct section prefix and query string.
> 
> - **JSON link:** set `href` to `this.buildURL()`.
> - **CSV link:** set `href` to `this.buildURL() + '&format=csv'` (the client URL already contains `?` from params).


</p>
</details> 